### PR TITLE
feat: respect `$DETECTOR_PATH`

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,14 @@ git clone git@eicweb.phy.anl.gov:EIC/benchmarks/reconstruction_benchmarks.git
       - materials etc. are referenced by name in `compact/drich.xml`
       - most of these tables were obtained from the
         [common optics class](https://github.com/cisbani/dRICh/blob/main/share/source/g4dRIChOptics.hh)
-    - the full detector compact file is `epic.xml`, which is generated via
+    - the full detector compact file is `$DETECTOR_PATH/epic.xml`, which is generated via
       Jinja during `cmake` (run `build_epic.sh`), along with a dRICH-only
-      compact file `epic_drich_only.xml`; these compact files are used by many
-      scripts, such as `npsim` (whereas `compact/drich.xml` is *only* for the
-      dRICH implementation itself)
+      compact file `$DETECTOR_PATH/epic_drich_only.xml`
+      - these compact files are used by many scripts, such as `npsim`, whereas
+        `compact/drich.xml` is *only* for the dRICH implementation itself
+      - `build_epic.sh` (`cmake`) will also copy local `epic/compact/*.xml`
+        files to `$DETECTOR_PATH`, since the generated compact files (`$DETECTOR_PATH/epic*.xml`) 
+        reference compact files in `$DETECTOR_PATH`
     - `src/DRICH_geo.cpp` is the C++ source file for the dRICH
       - relies on constants from the compact files
       - builds the dRICH
@@ -223,10 +226,10 @@ git clone git@eicweb.phy.anl.gov:EIC/benchmarks/reconstruction_benchmarks.git
       - see comments within the code for documentation
 
 ## Viewing the Geometry and Parameter Values
-- run `./run_dd_web_display.sh` to produce the geometry ROOT file
-  - by default, it will use the compact file for the *full* detector
-  - run `./run_dd_web_display.sh d` to run on dRICH only
-  - output ROOT file will be in `geo/`
+- run `./run_dd_web_display.sh` to produce the `TGeo` geometry ROOT file
+  - follow the usage guide to specify whether to draw the full EPIC
+    detector, or just the dRICH
+  - output ROOT file will be in `geo/`, by default
 - open the resulting ROOT file in `jsroot` geoviewer, using either:
   - [CERN host](https://root.cern/js/) (recommended)
   - Local host (advanced, but offers better control) - see [setup guide](doc/jsroot.md)

--- a/build_epic.sh
+++ b/build_epic.sh
@@ -12,10 +12,13 @@ if [ $clean -eq 1 ]; then
   echo "--- CLEAN: clean build dir..."
   mkdir -p build
   rm -rv build
-  echo "--- CLEAN: remove locally rendered compact files..."
+  echo "--- CLEAN: locally rendered top-level compact files..."
   rm -vf epic*.xml
-  echo "--- CLEAN: remove variant drich compact files..."
+  echo "--- CLEAN: transient files from scripts/vary_params.rb..."
+  rm -vf epic_drich_variant*.xml
   rm -vf compact/drich_variant*.xml
+  rm -vf ${DETECTOR_PATH}/epic_drich_variant*.xml
+  rm -vf ${DETECTOR_PATH}/compact/drich_variant*.xml
 fi
 
 cmake -B build -S . \

--- a/run_dd_web_display.sh
+++ b/run_dd_web_display.sh
@@ -1,37 +1,67 @@
 #!/bin/bash
 set -e
 
+# check environment
+if [ -z "$DETECTOR_PATH" ]; then
+  echo "ERROR: source environ.sh first"
+  exit 1
+fi
+
 # default output file
-geoDir=$(pwd)/geo
+geoDir=geo
 outputFile=$geoDir/detector_geometry.root
 mkdir -p $geoDir
 
-# set compact file, depending on (optional) argument; default is full epic
-case $1 in
-  d)
-    compactFile="epic_drich_only.xml"
-    ;;
-  p)
-    compactFile="epic_pfrich_only.xml"
-    ;;
-  c)
-    if [ $# -lt 3 ]; then
-      echo "ARG 'c' requires <compactFile> and <outputFile>"
-      exit 2
-    fi
-    compactFile=$(echo $2 | sed 's;^epic/;;')
-    outputFile=$(pwd)/$3
-    ;;
-  *)
-    compactFile="epic.xml"
-esac
-echo "compactFile = $compactFile"
-echo "outputFile  = $outputFile"
+# usage
+function usage {
+  echo """
+USAGE:
+  $0 [MODE] [OPTIONS]...
+
+  MODES: (one required)
+    -e  full EPIC detector
+    -d  dRICH only
+    -p  pfRICH only
+    -c <compact_file>
+        custom compact file
+     
+    For -e,-d,-p, compact files are assumed to be at
+     \$DETECTOR_PATH = $DETECTOR_PATH
+     (rendered by build_epic.sh)
+
+  OPTIONS
+    -o <output_root_file>
+        Output ROOT file with TGeo geometry (view with jsroot)
+        [ default = $outputFile ]
+
+  """
+  exit 2
+}
+if [ $# -eq 0 ]; then usage; fi
+
+# parse options
+while getopts "hedpc:o:" opt; do
+  case $opt in
+    h|\?) usage ;;
+    e) compactFile="${DETECTOR_PATH}/${DETECTOR}.xml" ;;
+    d) compactFile="${DETECTOR_PATH}/${DETECTOR}_drich_only.xml" ;;
+    p) compactFile="${DETECTOR_PATH}/${DETECTOR}_pfrich_only.xml" ;;
+    c) compactFile=$OPTARG ;;
+    o) outputFile=$OPTARG ;;
+  esac
+done
+echo """
+compactFile = $compactFile
+outputFile  = $outputFile
+"""
+if [ -z "$compactFile" ]; then
+  echo "ERROR: specify MODE"
+  usage
+  exit 1
+fi
 
 # produce geometry root file
-pushd epic
 dd_web_display --export -o $outputFile $compactFile
-popd
 echo ""
 echo "produced $outputFile"
 echo " -> open it with jsroot to view the geometry"

--- a/scripts/src/create_irt_auxfile.py
+++ b/scripts/src/create_irt_auxfile.py
@@ -21,7 +21,7 @@ import DDG4
 if not 'DETECTOR_PATH' in os.environ:
     print('ERROR: env var DETECTOR_PATH not set',file=sys.stderr)
     exit(1)
-mainFile = os.environ['DETECTOR_PATH'] + '/epic.xml'
+mainFile = os.environ['DETECTOR_PATH'] + '/' + os.environ['DETECTOR'] + '.xml'
 richFile = os.environ['DETECTOR_PATH'] + '/compact/drich.xml'
 
 ########################################

--- a/search_compact_params.sh
+++ b/search_compact_params.sh
@@ -6,4 +6,11 @@ if [ $# -ne 1 ]; then
   exit 2
 fi
 
-npdet_info search $1 --value epic/epic.xml
+if [ -z "$DETECTOR_PATH" ]; then
+  echo "ERROR: source environ.sh first"
+  exit 1
+fi
+
+compact_file=$DETECTOR_PATH/$DETECTOR.xml
+echo "Searching compact file $compact_file"
+npdet_info search $1 --value $compact_file


### PR DESCRIPTION
close https://github.com/eic/drich-dev/issues/22

Use rendered compact files in `$DETECTOR_PATH`, which `environ.sh` sets to `$EIC_SHELL_PREFIX/$DETECTOR`