### PR TITLE
fix: use EDM4hep output format by default for `npsim` in `simulate.py`

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -31,6 +31,7 @@ runType = 'run'
 numEvents = 50
 outputImageType = ''
 outputFileName = ''
+useEDM4hepFormat = True
 
 helpStr = f'''
 {sys.argv[0]} <INPUT_FILE or TEST_NUM> [OPTIONS]
@@ -83,13 +84,17 @@ helpStr = f'''
                      still save an output image, use Xvbf (start EIC container shell
                      as `xvfb-run eic-shell`); this is good for batch processing
                 -o [output file]: output root file name (overrides any default name)
+                -f: use TTree output format, rather than the default EDM4hep format, which
+                    is a TTree with PODIO metadata. The EDM4hep format is required
+                    for downstream reconstruction code, whereas the '-f' option produces
+                    a file which is easier to view in a TBrowser
     '''
 
 if (len(sys.argv) <= 1):
     print(helpStr)
     sys.exit(2)
 try:
-    opts, args = getopt.getopt(sys.argv[1:], 'i:t:d:sc:p:n:e:rvm:o:')
+    opts, args = getopt.getopt(sys.argv[1:], 'i:t:d:sc:p:n:e:rvm:o:f')
 except getopt.GetoptError:
     print('\n\nERROR: invalid argument\n', helpStr)
     sys.exit(2)
@@ -106,6 +111,7 @@ for opt, arg in opts:
     if (opt == '-v'): runType = 'vis'
     if (opt == '-m'): outputImageType = arg.lstrip()
     if (opt == '-o'): outputFileName = arg.lstrip()
+    if (opt == '-f'): useEDM4hepFormat = False
 if (testNum < 0 and inputFileName == ''):
     print('\n\nERROR: Please specify either an input file (`-i`) or a test number (`-t`).\n', helpStr)
     sys.exit(2)
@@ -139,6 +145,10 @@ elif not bool(re.search('^/', outputFileName)):
 ##### get output file basename
 outputName = re.sub('\.root$', '', outputFileName)
 outputName = re.sub('^.*/', '', outputName)
+##### set output file name for `npsim`, which is sensitive to file extension
+outputFileName_npsim = outputFileName
+if useEDM4hepFormat:
+    outputFileName_npsim = re.sub('\.root$', '.edm4hep.root', outputFileName_npsim)
 
 ### set RICH names, based on zDirection
 zDirection /= abs(zDirection)
@@ -449,7 +459,7 @@ cmd = [
         'npsim',
         f'--runType {runType}',
         f'--compactFile {compactFile}',
-        f'--outputFile {outputFileName}',
+        f'--outputFile {outputFileName_npsim}',
         "--part.userParticleHandler=''", # necessary for opticalphotons truth output
         # '--random.seed 1',
         # '--part.keepAllParticles True',
@@ -469,6 +479,9 @@ else:
 cmdShell = shlex.split(" ".join(cmd))
 print(f'{sep}\nRUN SIMULATION:\n{shlex.join(cmdShell)}\n{sep}')
 subprocess.run(cmdShell, cwd=detPath)
+
+### correct the output file name to the specified name
+os.rename(outputFileName_npsim, outputFileName)
 
 ### cleanup
 # os.remove(m.name) # remove macro


### PR DESCRIPTION
- uses `.edm4hep.root` as the output file extension for `npsim`, so that
  it knows to produce EDM4hep output
- renames the output file to your specified output name
- use option `-f` if you want to use the TTree output format