### PR TITLE
feat: consolidate build scripts to one `build.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out
 irt
 epic
 EDM4eic
+EDM4hep
 reconstruction_benchmarks
 NPDet
 DD4hep

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ of branches for varying configurations.
   [flowchart](doc/docDiagram.pdf) dependency graph)
   - build scripts, in recommended order:
   ```bash
-  ./build_EDM4eic.sh
-  ./build_irt.sh
-  ./build_epic.sh
-  ./build_juggler.sh
+  ./build.sh EDM4eic
+  ./build.sh irt
+  ./build.sh epic
+  ./build.sh juggler
   ```
   - you could also run `./rebuild_all.sh` to (re)build all of the modules in the
     recommended order
@@ -222,11 +222,11 @@ git clone git@eicweb.phy.anl.gov:EIC/benchmarks/reconstruction_benchmarks.git
       - most of these tables were obtained from the
         [common optics class](https://github.com/cisbani/dRICh/blob/main/share/source/g4dRIChOptics.hh)
     - the full detector compact file is `$DETECTOR_PATH/epic.xml`, which is generated via
-      Jinja during `cmake` (run `build_epic.sh`), along with a dRICH-only
+      Jinja during `cmake` (run `build.sh epic`), along with a dRICH-only
       compact file `$DETECTOR_PATH/epic_drich_only.xml`
       - these compact files are used by many scripts, such as `npsim`, whereas
         `compact/drich.xml` is *only* for the dRICH implementation itself
-      - `build_epic.sh` (`cmake`) will also copy local `epic/compact/*.xml`
+      - `build.sh epic` (`cmake`) will also copy local `epic/compact/*.xml`
         files to `$DETECTOR_PATH`, since the generated compact files (`$DETECTOR_PATH/epic*.xml`) 
         reference compact files in `$DETECTOR_PATH`
     - `src/DRICH_geo.cpp` is the C++ source file for the dRICH
@@ -396,9 +396,9 @@ This section contains notes for building upstream repositories. Clone the reposi
 that you want to test to this top-level directory. The general build procedure is:
 ```bash
 source environ.sh
-scripts/build_DD4hep.sh
+build.sh DD4hep
 source scripts/this_DD4hep.sh
-scripts/build_NPDet.sh
+build.sh NPDet
 source scripts/this_NPDet.sh  # note: you may prefer to directly call scripts in NPDet/install/bin
 rebuild_all.sh
 ```

--- a/build.sh
+++ b/build.sh
@@ -82,7 +82,6 @@ case $module in
     ;;
   DD4hep)
     prefix=$module/install
-    genOpt CMAKE_INSTALL_PREFIX=install
     genOpt DD4HEP_USE_GEANT4=ON
     genOpt DD4HEP_USE_EDM4HEP=ON
     genOpt DD4HEP_USE_HEPMC3=ON

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# general cmake wrapper, with module-specific settings
+
+set -e
+
+# check environment
+if [ -z "$DRICH_DEV" ]; then echo "ERROR: source environ.sh"; exit 1; fi
+if [ -z "$BUILD_NPROC" ]; then export BUILD_NPROC=1; fi
+
+# set module, and check for existence
+if [ $# -eq 0 ]; then
+  echo """
+  USAGE: $0 [MODULE] [OPTIONS]
+
+  - [MODULE] is a repository directory, e.g., \"epic\"
+
+  - [OPTIONS] will be passed to cmake
+    - pass no OPTIONS to use the defaults set in $0
+    - if the first OPTION is \"clean\", the build and install
+      directories will be cleaned
+  """
+  exit 2
+fi
+module=$(echo $1 | sed 's;/$;;')
+shift
+if [ ! -d "$module" ]; then
+  echo "ERROR: module \"$module\" does not exist"
+  exit 1
+fi
+
+# determine if clean build, and set extraOpts
+clean=0
+extraOpts=""
+if [ $# -ge 1 ]; then
+  if [ "$1" == "clean" ]; then
+    clean=1
+    shift
+  fi
+  extraOpts=$*
+fi
+echo """
+BUILDING:
+module    = $module
+clean     = $clean
+extraOpts = $extraOpts
+"""
+
+########################################
+# common options
+prefix=$EIC_SHELL_PREFIX
+nproc=$BUILD_NPROC
+
+########################################
+# module-specific options and preparation
+genOpts=""
+function genOpt() { genOpts+="-D$* "; }
+case $module in
+  EDM4eic)
+    genOpt BUILD_DATA_MODEL=ON
+    ;;
+  irt)
+    genOpt DELPHES=ON
+    genOpt EVALUATION=OFF
+    ;;
+  epic)
+    genOpt IRT_AUXFILE=ON
+    ;;
+  juggler)
+    prefix=$JUGGLER_INSTALL_PREFIX
+    nproc=2 # maybe memory hungry
+    genOpt CMAKE_FIND_DEBUG_MODE=OFF
+    ;;
+  athena)
+    genOpt IRT_AUXFILE=ON
+    # symlink beamline compact files
+    printf "\nsymlink beamline to local...\n"
+    rm -vf $module/ip6
+    ln -svf $BEAMLINE_PATH/ip6 $module/ip6
+    ;;
+  NPDet)
+    prefix=$module/install
+    ;;
+  DD4hep)
+    prefix=$module/install
+    genOpt CMAKE_INSTALL_PREFIX=install
+    genOpt DD4HEP_USE_GEANT4=ON
+    genOpt DD4HEP_USE_EDM4HEP=ON
+    genOpt DD4HEP_USE_HEPMC3=ON
+    genOpt Boost_NO_BOOST_CMAKE=ON
+    genOpt DD4HEP_USE_LCIO=ON
+    genOpt BUILD_TESTING=ON
+    genOpt ROOT_DIR=$ROOTSYS
+    genOpt CMAKE_BUILD_TYPE=Release
+    ;;
+esac
+
+########################################
+# build cmake commands
+
+# set buildsystem generation command
+genOpt CMAKE_INSTALL_PREFIX=$prefix
+genOpts+=$extraOpts
+buildSys=$module/build
+cmakeGen="cmake -S $module -B $buildSys $genOpts"
+
+# set build command
+buildOpts="-j $nproc"
+# if [ $clean -eq 1 ]; then
+#   buildOpts+=" --fresh" # FIXME: need cmake 3.24+; replaces `rm $buildSys` below
+# fi
+cmakeBuild="cmake --build $buildSys -j$nproc"
+
+# set install command
+cmakeInstall="cmake --install $buildSys"
+
+# print
+printf """
+CMAKE COMMANDS:
+========================================\n
+[ generate ]\n$cmakeGen\n
+[ build ]\n$cmakeBuild\n
+[ install ]\n$cmakeInstall\n
+========================================\n
+"""
+
+########################################
+# module-specific cleans
+if [ $clean -eq 1 ]; then
+  # remove build system
+  # FIXME: delete when using `cmake --fresh`
+  echo "--- CLEAN BUILDSYSTEM $buildSys"
+  mkdir -p $buildSys
+  rm -rv $buildSys
+  case $module in
+    epic)
+      echo "--- CLEAN: rendered compact files from source directory..."
+      rm -vf $module/epic*.xml
+      echo "--- CLEAN: transient compact files from scripts/vary_params.rb..."
+      rm -vf $module/epic_drich_variant*.xml
+      rm -vf $module/compact/drich_variant*.xml
+      rm -vf ${DETECTOR_PATH}/epic_drich_variant*.xml
+      rm -vf ${DETECTOR_PATH}/compact/drich_variant*.xml
+      ;;
+  esac
+fi
+
+########################################
+# run cmake
+$cmakeGen
+$cmakeBuild
+$cmakeInstall
+
+########################################
+# post-cmake tasks
+case $module in
+  athena)
+    # make legacy prefix compatible with EPIC expectations
+    printf "\ncompatibility updates for built targets...\n"
+    rm -vf $DETECTOR_PATH/ip6
+    ln -svf $BEAMLINE_PATH/ip6 $DETECTOR_PATH/ip6
+    ln -svf $DETECTOR_PATH/compact/subsystem_views/drich_only.xml $DETECTOR_PATH/${DETECTOR}_drich_only.xml
+    ;;
+  NPDet)
+    printf "\nDone. To use, run:  source scripts/this_NPDet.sh\n\n"
+    printf "Troubleshooting: try instead to directly call scripts in NPDet/install/bin\n\n"
+    ;;
+  DD4hep)
+    printf "\nDone. To use, run:  source scripts/this_DD4hep.sh\n\n"
+    ;;
+esac

--- a/build.sh
+++ b/build.sh
@@ -117,7 +117,7 @@ cmakeInstall="cmake --install $buildSys"
 printf """
 CMAKE COMMANDS:
 ========================================\n
-[ generate ]\n$cmakeGen\n
+[ generate buildsystem ]\n$cmakeGen\n
 [ build ]\n$cmakeBuild\n
 [ install ]\n$cmakeInstall\n
 ========================================\n

--- a/doc/athena.md
+++ b/doc/athena.md
@@ -15,8 +15,8 @@ source deprecated/environ_athena.sh   # overrides for ATHENA
 
 Build the ATHENA geometry, then re-build Juggler:
 ```bash
-deprecated/build_athena.sh clean
-build_juggler.sh clean
+build.sh athena clean
+build.sh juggler clean
 ```
 
 Revert to EPIC
@@ -24,6 +24,6 @@ Revert to EPIC
 To switch your environment back to EPIC:
 ```bash
 source environ.sh
-build_epic.sh clean
-build_juggler.sh clean
+build.sh epic clean
+build.sh juggler clean
 ```

--- a/rebuild_all.sh
+++ b/rebuild_all.sh
@@ -2,7 +2,7 @@
 # rebuild all modules, in order of dependence
 # pass an argument to rebuild everything cleanly
 set -e
-./build_EDM4eic.sh $*
-./build_irt.sh $*
-./build_epic.sh $*
-./build_juggler.sh $*
+./build.sh EDM4eic $*
+./build.sh irt     $*
+./build.sh epic    $*
+./build.sh juggler $*

--- a/run_dd_web_display.sh
+++ b/run_dd_web_display.sh
@@ -27,7 +27,7 @@ USAGE:
      
     For -e,-d,-p, compact files are assumed to be at
      \$DETECTOR_PATH = $DETECTOR_PATH
-     (rendered by build_epic.sh)
+     (rendered by build.sh epic)
 
   OPTIONS
     -o <output_root_file>


### PR DESCRIPTION
To build module `MODULE`, instead of
```
build_MODULE.sh
build_MODULE.sh clean
```
this PR proposes
```
build.sh MODULE
build.sh MODULE clean
```
All `build_*.sh` scripts are consolidated into one. This script serves as a general `cmake` wrapper, with some (overridable) settings specific to each module; it can also run a generic `cmake` build+install for any other module (that uses `cmake`)
