### PR TITLE
fix: instead of `--part.userParticleHandler=''`, reduce `part.minimalKineticEnergy`

### DIFF
--- a/scripts/momentum_scan.rb
+++ b/scripts/momentum_scan.rb
@@ -7,8 +7,8 @@ require 'fileutils'
 require 'pycall/import'
 
 ## settings
-NumEvents      = 100                 # number of events per fixed momentum
-NumPoints      = 20                  # number of momenta to sample
+NumEvents      = 50                  # number of events per fixed momentum
+NumPoints      = 10                  # number of momenta to sample
 PoolSize       = 6                   # number of parallel threads to run
 OutputDir      = 'out/momentum_scan' # output directory ( ! will be overwritten ! )
 RunSimRec      = true                # if false, do not run simulation+reconstruction, only draw the result

--- a/simulate.py
+++ b/simulate.py
@@ -478,7 +478,8 @@ cmd = [
         f'--runType {runType}',
         f'--compactFile {compactFile}',
         f'--outputFile {outputFileName_npsim}',
-        "--part.userParticleHandler=''", # necessary for opticalphotons truth output
+        # "--part.userParticleHandler=''", # necessary for opticalphotons truth output (REMOVE THIS?)
+        '--part.minimalKineticEnergy "0*eV"', # allow opticalphotons in trackers (dRICH) to be included in output
         # '--random.seed 1',
         # '--part.keepAllParticles True',
         ]


### PR DESCRIPTION
So far we run `npsim` with `--part.userParticleHandler=''`, which we thought we needed in order to see optical photons in the truth output. Today I learned we don't see them because the default `part.minimalKineticEnergy` is 1 MeV, too high for photons. Instead, we set this minimal energy to zero, and check if IRT reconstruction still works.