### PR TITLE
doc: all module primary branches are now `main`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ irt
 epic
 EDM4eic
 EDM4hep
+EICrecon
 reconstruction_benchmarks
 NPDet
 DD4hep

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ of branches for varying configurations.
 - be mindful of which branch you are on in each repository, especially if you
   have several active pull requests
   - for example, `irt` requires the new `EDM4eic` components and datatypes, which
-    at the time of writing this have not been merged to `EDM4eic` `master`
+    at the time of writing this have not been merged to `EDM4eic` `main`
   - use `./check_branches.sh` to quickly check which branches you are on in all
     repositories
   - use `./check_status.sh` to run `git status` in each repository, which is

--- a/doc/athena-branches.md
+++ b/doc/athena-branches.md
@@ -4,7 +4,7 @@ These are the branches we used for the ATHENA proposal:
 | Repository                  | New Branch                  | Old Proposal Branch |
 | --:                         | ---                         | ---                 |
 | `irt`                       | `irt-init-v02`              | `irt-init-v01`      |
-| `ip6`                       | `master`                    | `master`            |
+| `ip6`                       | `main`                      | `master`            |
 | `athena`                    | `144-irt-geometry`          | `irt-init-v01`      |
 | `eicd`                      | `irt-data-model`            | `irt-init-v01`      |
 | `juggler`                   | `73-add-rich-irt-algorithm` | `irt-init-v01`      |

--- a/doc/branches.md
+++ b/doc/branches.md
@@ -5,13 +5,13 @@ project or recommended configuration. Links to corresponding pull requests are p
 We intend to keep these tables up-to-date as development proceeds.
 
 ## Production
-| Repository                  | Branch   |
-| --:                         | ---      |
-| `drich-dev`                 | `main`   |
-| `epic`                      | `main`   |
-| `EDM4eic`                   | `master` |
-| `irt`                       | `main`   |
-| `juggler`                   | `master` |
+| Repository  | Branch |
+| --:         | ---    |
+| `drich-dev` | `main` |
+| `epic`      | `main` |
+| `EDM4eic`   | `main` |
+| `irt`       | `main` |
+| `juggler`   | `main` |
 
 ## IRT Development
 | Repository                  | Branch                                                          | Pull Request                                                                                             |
@@ -30,5 +30,5 @@ We intend to keep these tables up-to-date as development proceeds.
 | --:         | ---                                                 | ---                                                                                                          |
 | `drich-dev` | `main`                                              |                                                                                                              |
 | `epic`      | `12-drich-sensor-material-should-not-be-airoptical` | [MR at EICweb](https://eicweb.phy.anl.gov/EIC/detectors/ecce/-/merge_requests/28) - **TODO: convert to PR**  |
-| `EDM4eic`   | `master`                                            |                                                                                                              |
+| `EDM4eic`   | `main`                                              |                                                                                                              |
 | `irt`       | `main`                                              |                                                                                                              |


### PR DESCRIPTION
All have now changed `master`->`main`; this PR updates our documentation accordingly. It also adds `EICrecon` to `.gitignore`.