### PR TITLE
feat: update geometry viewer and constants wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ git clone git@eicweb.phy.anl.gov:EIC/benchmarks/reconstruction_benchmarks.git
       - see comments within the code for documentation
 
 ## Viewing the Geometry and Parameter Values
-- run `./run_dd_web_display.sh` to produce the `TGeo` geometry ROOT file
+- run `./geometry.sh` to produce the `TGeo` geometry ROOT file
   - follow the usage guide to specify whether to draw the full EPIC
     detector, or just the dRICH
   - output ROOT file will be in `geo/`, by default

--- a/doc/jsroot.md
+++ b/doc/jsroot.md
@@ -24,6 +24,6 @@ if yours is different)
 
 Various settings can be set via the URL. For example, the following URL
 automatically opens the `detector_geometry.root` file (produced by
-`run_dd_web_display.sh`) using `file=...`, and enables dark mode:
+`geometry.sh`) using `file=...`, and enables dark mode:
 
 <http://localhost:8000/?file=geo/detector_geometry.root&dark>

--- a/geometry.sh
+++ b/geometry.sh
@@ -19,9 +19,12 @@ USAGE:
   $0 [MODE] [OPTIONS]...
 
   MODES: (one required)
-    -e  full EPIC detector
     -d  dRICH only
     -p  pfRICH only
+    -m  mRICH only
+    -e  full EPIC detector
+    -a  full EPIC detector, arches configuration
+    -b  full EPIC detector, brycecanyon configuration
     -c <compact_file>
         custom compact file
      
@@ -40,12 +43,15 @@ USAGE:
 if [ $# -eq 0 ]; then usage; fi
 
 # parse options
-while getopts "hedpc:o:" opt; do
+while getopts "hdpmeabc:o:" opt; do
   case $opt in
     h|\?) usage ;;
-    e) compactFile="${DETECTOR_PATH}/${DETECTOR}.xml" ;;
     d) compactFile="${DETECTOR_PATH}/${DETECTOR}_drich_only.xml" ;;
     p) compactFile="${DETECTOR_PATH}/${DETECTOR}_pfrich_only.xml" ;;
+    m) compactFile="${DETECTOR_PATH}/${DETECTOR}_mrich_only.xml" ;;
+    e) compactFile="${DETECTOR_PATH}/${DETECTOR}.xml" ;;
+    a) compactFile="${DETECTOR_PATH}/${DETECTOR}_arches.xml" ;;
+    b) compactFile="${DETECTOR_PATH}/${DETECTOR}_brycecanyon.xml" ;;
     c) compactFile=$OPTARG ;;
     o) outputFile=$OPTARG ;;
   esac
@@ -61,7 +67,7 @@ if [ -z "$compactFile" ]; then
 fi
 
 # produce geometry root file
-dd_web_display --export -o $outputFile $compactFile
+geoConverter -compact2tgeo -input $compactFile -output $outputFile
 echo ""
 echo "produced $outputFile"
 echo " -> open it with jsroot to view the geometry"

--- a/ruby/variator/variator_base.rb
+++ b/ruby/variator/variator_base.rb
@@ -37,7 +37,7 @@ class VariatorBase
       ]],
       ### draw geometry
       [[
-        './run_dd_web_display.sh',
+        './geometry.sh',
         "-c #{settings[:compact_detector]}", 
         "-o #{settings[:output].sub(/root$/,'geometry.root')}",
       ]],

--- a/search_compact_params.sh
+++ b/search_compact_params.sh
@@ -1,16 +1,55 @@
 #!/bin/bash
 # return parameter value(s) from compact files, given search term
+set -e
 
-if [ $# -ne 1 ]; then
-  echo "USAGE: $0 [search term (case sensitive)]"
-  exit 2
-fi
-
+# check environment
 if [ -z "$DETECTOR_PATH" ]; then
   echo "ERROR: source environ.sh first"
   exit 1
 fi
 
-compact_file=$DETECTOR_PATH/$DETECTOR.xml
-echo "Searching compact file $compact_file"
-npdet_info search $1 --value $compact_file
+# usage
+function usage {
+  echo """
+USAGE:
+  $0 [CONFIGURATION]
+
+  CONFIGURATIONS: (one required)
+    -e  default EPIC detector
+    -a  arches (mRICH)
+    -b  brycecanyon (pfRICH)
+    -c <compact_file>
+        custom compact file
+     
+    For -e,-a,-b, compact files are assumed to be at
+     \$DETECTOR_PATH = $DETECTOR_PATH
+     (rendered by build.sh epic)
+
+  Use grep to search the output
+
+  """
+  exit 2
+}
+if [ $# -eq 0 ]; then usage; fi
+
+# parse options
+while getopts "heabc:" opt; do
+  case $opt in
+    h|\?) usage ;;
+    e) compactFile="${DETECTOR_PATH}/${DETECTOR}.xml" ;;
+    a) compactFile="${DETECTOR_PATH}/${DETECTOR}_arches.xml" ;;
+    b) compactFile="${DETECTOR_PATH}/${DETECTOR}_brycecanyon.xml" ;;
+    c) compactFile=$OPTARG ;;
+  esac
+done
+echo """
+compactFile = $compactFile
+"""
+if [ -z "$compactFile" ]; then
+  echo "ERROR: specify CONFIGURATION"
+  usage
+  exit 1
+fi
+
+# dump table
+npdet_info dump $compactFile


### PR DESCRIPTION
- `geometry.sh` replaces `run_dd_web_display.sh`, and now uses the `geoConverter` option
- `search_compact_params.sh` has been changed a bit to allow searching for constants for differing full EPIC configurations (arches vs. brycecanyon)
