### PR TITLE
feat: build `EDM4hep` for `eic-shell` override

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,10 @@ case $module in
   EDM4eic)
     genOpt BUILD_DATA_MODEL=ON
     ;;
+  EDM4hep)
+    genOpt BUILD_DATA_MODEL=ON
+    genOpt USE_EXTERNAL_CATCH2=OFF
+    ;;
   irt)
     genOpt CMAKE_BUILD_TYPE=Debug  # build with debugging symbols
     genOpt DELPHES=ON
@@ -188,5 +192,8 @@ case $module in
     ;;
   DD4hep)
     printf "\nDone. To use, run:  source scripts/this_DD4hep.sh\n\n"
+    ;;
+  EDM4hep)
+    printf "\nDone. To use, run:  export EDM4HEP_ROOT=$prefix\n\n"
     ;;
 esac

--- a/scripts/this_DD4hep.sh
+++ b/scripts/this_DD4hep.sh
@@ -17,6 +17,9 @@ export LD_LIBRARY_PATH=$DD4hep_ROOT/lib:$LD_LIBRARY_PATH_TMP
 # thisdd4hep.sh also doens't select the newly installed examples
 export DD4HEP=$DD4hep_ROOT/examples
 
+# add /usr/local/bin back to $PATH (workaround..)
+export PATH="/usr/local/bin:$PATH"
+
 
 # old test version (not using thisdd4hep.sh)
 # export DD4hep_ROOT=$DRICH_DEV/DD4hep/install


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add support to `build.sh` for `EDM4hep`. This requires the subsequent setting of `$EDM4hep_ROOT` to take effect (`build.sh` will print this message).

This PR also adds a quick workaround for the DD4hep override (usual problem of `/usr/local/bin` suddenly disappearing from `$PATH`).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no