### PR TITLE
fix: build `create_irt_auxfile.cpp` only if IRT ROOT dictionary was generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ FLAGS += -DSPDLOG_FMT_EXTERNAL
 #--------------------------------------------
 
 BIN_TARGET = bin
-EXECUTABLES := $(addprefix $(BIN_TARGET)/, $(basename $(notdir $(wildcard src/*.cpp))))
+SOURCES := $(wildcard src/*.cpp)
+EXECUTABLES := $(addprefix $(BIN_TARGET)/, $(basename $(notdir $(SOURCES))))
 
 EICRECON_DIR = ${DRICH_DEV}/EICrecon/src/services/geometry/richgeo
 DEPS += -I$(EICRECON_DIR)
@@ -36,22 +37,43 @@ IRTGEO_ROOT = $(EICRECON_DIR)
 IRTGEO_SOURCES := $(wildcard $(IRTGEO_ROOT)/IrtGeo*.cc)
 IRTGEO_HEADERS := $(wildcard $(IRTGEO_ROOT)/IrtGeo*.h) $(IRTGEO_ROOT)/RichGeo.h
 
+IRT_AUXFILE_SOURCE = src/create_irt_auxfile.cpp
+IRT_AUXFILE_EXECUTABLE = $(BIN_TARGET)/create_irt_auxfile
+SOURCES := $(filter-out $(IRT_AUXFILE_SOURCE), $(SOURCES))
+EXECUTABLES := $(filter-out $(IRT_AUXFILE_EXECUTABLE), $(EXECUTABLES))
+
 #--------------------------------------------
 
-all: $(IRTGEO_LIB) $(EXECUTABLES)
+all: $(EXECUTABLES) $(IRTGEO_LIB) $(IRT_AUXFILE_EXECUTABLE)
+
+$(EXECUTABLES): $(BIN_TARGET)/%: src/%.cpp
+	mkdir -p $(BIN_TARGET)
+	@echo "----- build $@.o -----"
+	$(CXX) -c $< -o $@.o $(FLAGS) $(DEPS)
+	@echo "--- make executable $@"
+	$(CXX) -o $@ $@.o $(LIBS)
+	$(RM) $@.o
 
 $(IRTGEO_LIB): $(IRTGEO_HEADERS) $(IRTGEO_SOURCES)
+ifeq ($(IRT_ROOT_DICT_FOUND),"1")
 	mkdir -p $(LIB_TARGET)
 	@echo "----- build $@ -----"
 	$(CXX) $(IRTGEO_SOURCES) -shared -o $@ $(FLAGS) $(DEPS) $(LIBS)
+else
+	@echo "WARNING: skip building $@ since IRT ROOT dict not found"
+endif
 
-$(BIN_TARGET)/%: src/%.cpp $(IRTGEO_LIB)
+$(IRT_AUXFILE_EXECUTABLE): $(IRT_AUXFILE_SOURCE) $(IRTGEO_LIB)
+ifeq ($(IRT_ROOT_DICT_FOUND),"1")
 	mkdir -p $(BIN_TARGET)
 	@echo "----- build $@.o -----"
 	$(CXX) -c $< -o $@.o $(FLAGS) $(DEPS)
 	@echo "--- make executable $@"
 	$(CXX) -o $@ $@.o $(LIBS) -L$(LIB_TARGET) -l$(IRTGEO_LIB_NAME)
 	$(RM) $@.o
+else
+	@echo "WARNING: skip building $@ since IRT ROOT dict not found"
+endif
 
 clean:
 	@echo "CLEAN ======================================================"

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ $(EXECUTABLES): $(BIN_TARGET)/%: src/%.cpp
 	$(RM) $@.o
 
 $(IRTGEO_LIB): $(IRTGEO_HEADERS) $(IRTGEO_SOURCES)
-ifeq ($(IRT_ROOT_DICT_FOUND),"1")
+ifeq ($(IRT_ROOT_DICT_FOUND),1)
 	mkdir -p $(LIB_TARGET)
 	@echo "----- build $@ -----"
 	$(CXX) $(IRTGEO_SOURCES) -shared -o $@ $(FLAGS) $(DEPS) $(LIBS)
@@ -64,7 +64,7 @@ else
 endif
 
 $(IRT_AUXFILE_EXECUTABLE): $(IRT_AUXFILE_SOURCE) $(IRTGEO_LIB)
-ifeq ($(IRT_ROOT_DICT_FOUND),"1")
+ifeq ($(IRT_ROOT_DICT_FOUND),1)
 	mkdir -p $(BIN_TARGET)
 	@echo "----- build $@.o -----"
 	$(CXX) -c $< -o $@.o $(FLAGS) $(DEPS)
@@ -77,5 +77,5 @@ endif
 
 clean:
 	@echo "CLEAN ======================================================"
-	$(RM) $(EXECUTABLES) $(IRTGEO_LIB)
+	$(RM) $(EXECUTABLES) $(IRT_AUXFILE_EXECUTABLE) $(IRTGEO_LIB)
 

--- a/environ.sh
+++ b/environ.sh
@@ -38,6 +38,13 @@ if [ -f $EIC_SHELL_PREFIX/bin/eicrecon-this.sh ]; then
   export PATH="$PATH:/usr/local/bin"
 fi
 
+# check if we have ROOT I/O enabled for IRT
+export IRT_ROOT_DICT_FOUND=0
+if [ -f $EIC_SHELL_PREFIX/lib/libIRT_rdict.pcm -a -f $EIC_SHELL_PREFIX/lib/libIRT.rootmap ]; then
+  export IRT_ROOT_DICT_FOUND=1
+elif [ -f /usr/local/lib/libIRT_rdict.pcm -a -f /usr/local/lib/libIRT.rootmap ]; then
+  export IRT_ROOT_DICT_FOUND=1
+fi
 
 # environment overrides:
 # - prefer local juggler build
@@ -111,10 +118,11 @@ LD_LIBRARY_PATH:
   $(echo $LD_LIBRARY_PATH | sed 's/:/\n  /g')
 
 Common:
-  DRICH_DEV        = $DRICH_DEV
-  BUILD_NPROC      = $BUILD_NPROC
-  EIC_SHELL_PREFIX = $EIC_SHELL_PREFIX
-  JANA_PLUGIN_PATH = $JANA_PLUGIN_PATH
-  DETECTOR_PATH    = $DETECTOR_PATH
+  DRICH_DEV           = $DRICH_DEV
+  BUILD_NPROC         = $BUILD_NPROC
+  EIC_SHELL_PREFIX    = $EIC_SHELL_PREFIX
+  JANA_PLUGIN_PATH    = $JANA_PLUGIN_PATH
+  DETECTOR_PATH       = $DETECTOR_PATH
+  IRT_ROOT_DICT_FOUND = $IRT_ROOT_DICT_FOUND
 
 """

--- a/src/create_irt_auxfile.cpp
+++ b/src/create_irt_auxfile.cpp
@@ -8,8 +8,8 @@
 
 // local
 #include "WhichRICH.h"
-#include "IrtGeoDRICH.h"
-#include "IrtGeoPFRICH.h"
+#include <IrtGeoDRICH.h>
+#include <IrtGeoPFRICH.h>
 
 int main(int argc, char** argv) {
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Resolve #79 

If no ROOT dictionary was generated for `irt`, then it is not possible to use `create_irt_auxfile.cpp`. This PR checks for dictionary existence in `environ.sh`, and sets a corresponding environment variable. The `Makefile` will only allow `create_irt_auxfile.cpp` to be built if the ROOT dictionary was found.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
no