### PR TITLE
ci: use `main` branch for all modules

### DIFF
--- a/scripts/configure_CI.sh
+++ b/scripts/configure_CI.sh
@@ -20,7 +20,7 @@ for repo in $repo_list; do
       git clone https://github.com/eic/EICrecon.git --branch main
       ;;
     reconstruction_benchmarks)
-      git clone https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks.git --branch irt-algo
+      git clone https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks.git --branch main
       ;;
     none)
       echo "Not cloning any repositories"

--- a/scripts/configure_CI.sh
+++ b/scripts/configure_CI.sh
@@ -20,7 +20,7 @@ for repo in $repo_list; do
       git clone https://github.com/eic/EICrecon.git --branch main
       ;;
     reconstruction_benchmarks)
-      git clone https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks.git --branch main
+      git clone https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks.git --branch master
       ;;
     none)
       echo "Not cloning any repositories"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Now that RICH benchmarks are merged, we may use `main` for all default CI tests.