### PR TITLE
doc: remove `irt-algo` and `irt-algo-stable` notes

### DIFF
--- a/config/recon_digi_only.yaml
+++ b/config/recon_digi_only.yaml
@@ -1,6 +1,5 @@
 ################################################################################
 # CONFIGURATION FILE FOR DRICH EICrecon USAGE
-# - use with EICrecon `git` branch `irt-algo` or `irt-algo-stable`
 ################################################################################
 
 ### PODIO collections to include in the output

--- a/config/recon_irt.yaml
+++ b/config/recon_irt.yaml
@@ -1,6 +1,5 @@
 ################################################################################
 # CONFIGURATION FILE FOR DRICH EICrecon USAGE
-# - use with EICrecon `git` branch `irt-algo` or `irt-algo-stable`
 ################################################################################
 
 ### EICrecon plugins

--- a/config/recon_irt_noise.yaml
+++ b/config/recon_irt_noise.yaml
@@ -1,6 +1,5 @@
 ################################################################################
 # CONFIGURATION FILE FOR DRICH EICrecon USAGE
-# - use with EICrecon `git` branch `irt-algo` or `irt-algo-stable`
 ################################################################################
 
 ### EICrecon plugins

--- a/doc/branches.md
+++ b/doc/branches.md
@@ -14,20 +14,7 @@ We intend to keep these tables up-to-date as development proceeds.
 | `EICrecon`                  | `main`   |
 | `reconstruction_benchmarks` | `master` |
 
-## IRT -- EICrecon development
-| Repository                  | Branch                             | Pull Request                                                                                       |
-| --:                         | ---                                | ---                                                                                                |
-| `drich-dev`                 | `main`                             |                                                                                                    |
-| `epic`                      | `main`                             |                                                                                                    |
-| `EDM4eic`                   | `main`                             |                                                                                                    |
-| `irt`                       | `main`                             |                                                                                                    |
-| `EICrecon`                  | `irt-algo-stable` (or `irt-algo`)  | https://github.com/eic/EICrecon/pull/393                                                           |
-| `reconstruction_benchmarks` | `irt-algo`                         | [MR 293](https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks/-/merge_requests/293) |
-
-- the branch `irt-algo-stable` is for a stable, working version; the branch
-  `irt-algo` is for the unstable, most up-to-date version
-
-## IRT -- Legacy Juggler Support
+## IRT -- Legacy Juggler Support (DEPRECATED, replaced by EICrecon)
 | Repository  | Branch                      | Pull Request                                                                |
 | --:         | ---                         | ---                                                                         |
 | `drich-dev` | `main`                      |                                                                             |

--- a/doc/tutorials/3-running-reconstruction.md
+++ b/doc/tutorials/3-running-reconstruction.md
@@ -11,55 +11,24 @@ Before attending this tutorial, please build the reconstruction and benchmarks s
 
 ### Obtaining the Software
 
-At the time of writing this tutorial, dRICH PID is still not fully approved in the `main` branches of the reconstruction and benchmarks software. The current development branch is `irt-algo` for both; `irt-algo` on EICrecon is somewhat unstable, so instead I recommend you to use `irt-algo-stable`, which at times may be a bit behind `irt-algo`.
-
-If you already have clones of `EICrecon` and `reconstruction_benchmarks`, you can switch branches by running the commands below. Most likely you have a clone of `EICrecon` (on branch `main`), but do not have a clone of `reconstruction_benchmarks` (clone commands are also given below)
-
-- `EICrecon`:
-```bash
-pushd EICrecon
-git fetch origin
-git checkout irt-algo-stable    # or irt-algo, if you want bleeding edge
-popd
-```
-- `reconstruction_benchmarks`:
-```bash
-pushd reconstruction_benchmarks
-git fetch origin
-git checkout irt-algo    # no irt-algo-stable branch, since this code doesn't change as rapidly
-popd
-```
-
-Otherwise if you do not yet have clones of `EICrecon` and `reconstruction_benchmarks`, you can clone and checkout the appropriate branch in one command. As in [tutorial 1](1-setup-and-running-simulations.md), use HTTPS or SSH depending on your access credentials:
+If you do not yet have clones of `EICrecon` and `reconstruction_benchmarks`, you can clone and checkout the appropriate branch in one command. As in [tutorial 1](1-setup-and-running-simulations.md), use HTTPS or SSH depending on your access credentials:
 
 - `EICrecon` SSH:
 ```bash
-git clone git@github.com:eic/EICrecon.git --branch irt-algo-stable       # or irt-algo, if you want bleeding edge
+git clone git@github.com:eic/EICrecon.git
 ```
 - `EICrecon` HTTPS:
 ```bash
-git clone https://github.com/eic/EICrecon.git --branch irt-algo-stable   # or irt-algo, if you want bleeding edge
+git clone https://github.com/eic/EICrecon.git
 ```
 - `reconstruction_benchmarks` SSH:
 ```bash
-git clone git@eicweb.phy.anl.gov:EIC/benchmarks/reconstruction_benchmarks.git --branch irt-algo
+git clone git@eicweb.phy.anl.gov:EIC/benchmarks/reconstruction_benchmarks.git
 ```
 - `reconstruction_benchmarks` HTTPS:
 ```bash
-git clone https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks.git --branch irt-algo
+git clone https://eicweb.phy.anl.gov/EIC/benchmarks/reconstruction_benchmarks.git
 ```
-
-Verify that you are on the correct set of branches by running `./check_branches.sh`. The output should look something like:
-```
-                     drich-dev: main  (269bf3c)
-                          epic: main  (d14e80b)
-                       EDM4eic: NOT INSTALLED
-                           irt: NOT INSTALLED
-                      EICrecon: irt-algo-stable  (21fd271a)
-                       juggler: NOT INSTALLED
-     reconstruction_benchmarks: irt-algo  (d1c7885)
-```
-(the commit hashes, in parentheses, may differ)
 
 ### Building
 

--- a/doc/tutorials/5-reconstruction-code-part-2.md
+++ b/doc/tutorials/5-reconstruction-code-part-2.md
@@ -8,8 +8,6 @@ Tutorial 5: Reconstruction Code Part II
 
 Finally, let's go through the reconstruction code. Refer to [tutorial 4](4-reconstruction-code-part-1.md) for general guidance on the reconstruction code; this tutorial 5 will provide an overview of how the primary algorithms work.
 
-**IMPORTANT**: the presentation of this tutorial will assume that `EICrecon` is on the branch `irt-algo`. This is the most up-to-date branch containing the full dRICH PID implementation; in contrast, `irt-algo-stable` may be a bit behind `irt-algo`, but will most likely work (whereas `irt-algo` is unstable, and sometimes may be in a broken state). If `irt-algo` is not available, then that likely means all the dRICH PID code has been merged to `main`; in this case, refer to the `main` branch instead.
-
 ## Navigating EICrecon
 
 Each algorithm "`AlgorithmName`" typically includes 5 source code files:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
`irt-algo` is no more, delete its references.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [x] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no