### PR TITLE
fix: /usr/local -> /opt/local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ DEPS += -I${EIC_SHELL_PREFIX}/include/IRT
 DEPS += -Isrc
 
 # image libs
-LIBS += -L/usr/local/lib
+LIBS += -L/opt/local/lib
 LIBS += -lDDCore -lDDRec
 LIBS += -lpodio -lpodioRootIO -ledm4hep
 LIBS += -lfmt -lspdlog
 LIBS += -lG4global -lG4materials -lG4geometry -lG4persistency
-DEPS += -I/usr/local/include
+DEPS += -I/opt/local/include
 FLAGS += -DSPDLOG_FMT_EXTERNAL
 
 #--------------------------------------------

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ of branches for varying configurations.
     - the `eic-shell` script is used to start a container shell
     - all documentation below assumes you are running in `eic-shell`
     - this image contains all the dependencies needed for EPIC simulations
-      - tip: when in a container shell (`eic-shell`), see `/usr/local` or `/opt/software/linux.../gcc.../`
+      - tip: when in a container shell (`eic-shell`), see `/opt/local` or `/opt/software/linux.../gcc.../`
         for the installed software
         - for example, if you want to check exactly what is available in the
           [EDM4hep data model](https://github.com/key4hep/EDM4hep), see the headers

--- a/doc/tutorials/1-setup-and-running-simulations.md
+++ b/doc/tutorials/1-setup-and-running-simulations.md
@@ -78,7 +78,7 @@ You can find which versions of software are installed in `eic-shell` by running:
 ```bash
 eic-info
 ```
-You may also find the installations themselves at `/usr/local`, which is useful if you want to check header files or libraries.
+You may also find the installations themselves at `/opt/local`, which is useful if you want to check header files or libraries.
 
 Let's now build the local repositories, which will override the `eic-shell` builds.
 

--- a/doc/tutorials/4-reconstruction-code-part-1.md
+++ b/doc/tutorials/4-reconstruction-code-part-1.md
@@ -46,8 +46,8 @@ Now take a look at the YAML files. Here are links to them, along with the variou
 
 Being a YAML file, this expression of the data model is independent of any programming language. Code generation may be used to generate an API to use the data model in any preferred language. In ePIC, we use [PODIO](https://github.com/AIDASoft/podio) to generate C++ classes from these YAML files. You can find full documentation linked in the EDM Github repositories; alternatively, browse the C++ header files in `eic-shell` found in:
 ```bash
-/usr/local/include/edm4hep
-/usr/local/include/edm4eic
+/opt/local/include/edm4hep
+/opt/local/include/edm4eic
 ```
 
 See also [Thomas Madlener's CHEP 2023 talk](https://indico.jlab.org/event/459/contributions/11578/) for another resource on PODIO.

--- a/environ.sh
+++ b/environ.sh
@@ -31,12 +31,12 @@ source /opt/detector/setup.sh
 if [ -f $EIC_SHELL_PREFIX/bin/eicrecon-this.sh ]; then
   if [ -z "$CI" ]; then
     echo "PATCH: exclude container's EICrecon plugins from JANA_PLUGIN_PATH"
-    exc="/usr/local/lib/EICrecon/plugins"
+    exc="/opt/local/lib/EICrecon/plugins"
     export JANA_PLUGIN_PATH=$(echo $JANA_PLUGIN_PATH | sed "s;${exc}:;;g" | sed "s;:${exc};;g" | sed "s;${exc};;g" )
     echo "ENVIRONMENT: source EICrecon"
     source $EIC_SHELL_PREFIX/bin/eicrecon-this.sh
-    echo "PATCH: source thisroot.sh removes /usr/local/bin from PATH; add it back"
-    export PATH="$PATH:/usr/local/bin"
+    echo "PATCH: source thisroot.sh removes /opt/local/bin from PATH; add it back"
+    export PATH="$PATH:/opt/local/bin"
   else
     echo "On CI runner; only setting JANA_PLUGIN_PATH"
     export JANA_PLUGIN_PATH=$EIC_SHELL_PREFIX/lib/EICrecon/plugins${JANA_PLUGIN_PATH:+:${JANA_PLUGIN_PATH}}
@@ -47,7 +47,7 @@ fi
 export IRT_ROOT_DICT_FOUND=0
 if [ -f $EIC_SHELL_PREFIX/lib/libIRT_rdict.pcm -a -f $EIC_SHELL_PREFIX/lib/libIRT.rootmap ]; then
   export IRT_ROOT_DICT_FOUND=1
-elif [ -f /usr/local/lib/libIRT_rdict.pcm -a -f /usr/local/lib/libIRT.rootmap ]; then
+elif [ -f /opt/local/lib/libIRT_rdict.pcm -a -f /opt/local/lib/libIRT.rootmap ]; then
   export IRT_ROOT_DICT_FOUND=1
 fi
 

--- a/scripts/this_DD4hep.sh
+++ b/scripts/this_DD4hep.sh
@@ -17,8 +17,8 @@ export LD_LIBRARY_PATH=$DD4hep_ROOT/lib:$LD_LIBRARY_PATH_TMP
 # thisdd4hep.sh also doens't select the newly installed examples
 export DD4HEP=$DD4hep_ROOT/examples
 
-# add /usr/local/bin back to $PATH (workaround..)
-export PATH="$PATH:/usr/local/bin"
+# add /opt/local/bin back to $PATH (workaround..)
+export PATH="$PATH:/opt/local/bin"
 
 # update prompt
 export PS1="${PS1:-}"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
`eic-shell` uses `/opt/local` for installation now. Even better would be to avoid the need for hardcoded paths.